### PR TITLE
Add type arguments to reduce minimum java version to 6 (from 7)

### DIFF
--- a/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
+++ b/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
@@ -218,7 +218,7 @@ public class FactoryModPlugin extends JavaPlugin
 			ItemList<NamedItemStack> fuel=getItems(configSection.getConfigurationSection("fuel"));
 			if(fuel.isEmpty())
 			{
-				fuel=new ItemList<>();
+				fuel=new ItemList<NamedItemStack>();
 				fuel.add(new NamedItemStack(Material.getMaterial("COAL"),1,(short)1,"Charcoal"));
 			}
 			int fuelTime=configSection.getInt("fuel_time",2);
@@ -240,7 +240,7 @@ public class FactoryModPlugin extends JavaPlugin
 	}
 	private List<ProbabilisticEnchantment> getEnchantments(ConfigurationSection configEnchantments)
 	{
-		List<ProbabilisticEnchantment> enchantments=new ArrayList<>();
+		List<ProbabilisticEnchantment> enchantments=new ArrayList<ProbabilisticEnchantment>();
 		if(configEnchantments!=null)
 		{
 			Iterator<String> names=configEnchantments.getKeys(false).iterator();
@@ -262,7 +262,7 @@ public class FactoryModPlugin extends JavaPlugin
 	}
 	private ItemList<NamedItemStack> getItems(ConfigurationSection configItems)
 	{
-		ItemList<NamedItemStack> items=new ItemList<>();
+		ItemList<NamedItemStack> items=new ItemList<NamedItemStack>();
 		if(configItems!=null)
 		{
 			for(String commonName:configItems.getKeys(false))

--- a/src/com/github/igotyou/FactoryMod/Factorys/ProductionFactory.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/ProductionFactory.java
@@ -40,7 +40,7 @@ public class ProductionFactory extends FactoryObject implements Factory
 	{
 		super(factoryLocation, factoryInventoryLocation, factoryPowerSource, ProductionFactory.FACTORY_TYPE, subFactoryType);
 		this.productionFactoryProperties = (ProductionProperties) factoryProperties;
-		this.recipes=new ArrayList<> (productionFactoryProperties.getRecipes());
+		this.recipes=new ArrayList<ProductionRecipe> (productionFactoryProperties.getRecipes());
 		this.setRecipeToNumber(0);
 		this.currentRepair=0.0;
 		this.timeDisrepair=3155692597470L;//Year 2070, default starting value
@@ -191,7 +191,7 @@ public class ProductionFactory extends FactoryObject implements Factory
 	 */
 	public List<InteractionResponse> togglePower() 
 	{
-		List<InteractionResponse> response=new ArrayList<>();
+		List<InteractionResponse> response=new ArrayList<InteractionResponse>();
 		//if the factory is turned off
 		if (!active)
 		{
@@ -216,7 +216,7 @@ public class ProductionFactory extends FactoryObject implements Factory
 						//return a failure message, containing which materials are needed for the recipe
 						//[Requires the following: Amount Name, Amount Name.]
 						//[Requires one of the following: Amount Name, Amount Name.]
-						ItemList<NamedItemStack> needAll=new ItemList<>();
+						ItemList<NamedItemStack> needAll=new ItemList<NamedItemStack>();
 						needAll.addAll(currentRecipe.getInputs().getDifference(getInventory()));
 						needAll.addAll(currentRecipe.getRepairs().getDifference(getInventory()));
 						if(!needAll.isEmpty())
@@ -264,7 +264,7 @@ public class ProductionFactory extends FactoryObject implements Factory
 	 */
 	public List<InteractionResponse> toggleRecipes()
 	{
-		List<InteractionResponse> responses=new ArrayList<>();
+		List<InteractionResponse> responses=new ArrayList<InteractionResponse>();
 		//Is the factory off
 		if (!active)
 		{
@@ -485,7 +485,7 @@ public class ProductionFactory extends FactoryObject implements Factory
 	
 	public List<InteractionResponse> getChestResponse()
 	{
-		List<InteractionResponse> responses=new ArrayList<>();
+		List<InteractionResponse> responses=new ArrayList<InteractionResponse>();
 		String status=active ? "On" : "Off";
 		String percentDone=status.equals("On") ? " - "+Math.round(currentProductionTimer*100/currentRecipe.getProductionTime())+"% done." : "";
 		//Name: Status with XX% health.

--- a/src/com/github/igotyou/FactoryMod/recipes/ProductionRecipe.java
+++ b/src/com/github/igotyou/FactoryMod/recipes/ProductionRecipe.java
@@ -42,7 +42,7 @@ public class ProductionRecipe implements Recipe
 	
 	public ProductionRecipe(String title,String recipeName,int productionTime,ItemList<NamedItemStack> repairs)
 	{
-		this(title,recipeName,productionTime,new ItemList<>(),new ItemList<>(),new ItemList<>(),new ArrayList<ProbabilisticEnchantment>(),false,repairs);
+		this(title,recipeName,productionTime,new ItemList<NamedItemStack>(),new ItemList<NamedItemStack>(),new ItemList<NamedItemStack>(),new ArrayList<ProbabilisticEnchantment>(),false,repairs);
 	}
 	
 	public boolean hasMaterials(Inventory inventory)

--- a/src/com/github/igotyou/FactoryMod/utility/ItemList.java
+++ b/src/com/github/igotyou/FactoryMod/utility/ItemList.java
@@ -109,7 +109,7 @@ public class ItemList<E extends NamedItemStack> extends ArrayList<E> {
 	}
 	public ItemList<NamedItemStack> removeOneFrom(Inventory inventory)
 	{
-		ItemList<NamedItemStack> itemList=new ItemList<>();
+		ItemList<NamedItemStack> itemList=new ItemList<NamedItemStack>();
 		for(NamedItemStack itemStack:this)
 		{
 			if(removeItemStack(inventory,itemStack))
@@ -122,7 +122,7 @@ public class ItemList<E extends NamedItemStack> extends ArrayList<E> {
 	}
 	public ItemList<NamedItemStack> getDifference(Inventory inventory)
 	{
-		ItemList<NamedItemStack> missingItems=new ItemList<>();
+		ItemList<NamedItemStack> missingItems=new ItemList<NamedItemStack>();
 		for(NamedItemStack itemStack:this)
 		{
 			int difference=itemStack.getAmount()-amountAvailable(inventory, itemStack);
@@ -272,7 +272,7 @@ public class ItemList<E extends NamedItemStack> extends ArrayList<E> {
 	}
 	public ItemList<NamedItemStack> getMultiple(int multiplier)
 	{
-		ItemList<NamedItemStack> multipliedItemList=new ItemList<>();
+		ItemList<NamedItemStack> multipliedItemList=new ItemList<NamedItemStack>();
 		for (NamedItemStack itemStack:this)
 		{
 			NamedItemStack itemStackClone=itemStack.clone();


### PR DESCRIPTION
A particular syntax feature has been used which requires Java 7 (all the other major plugins are fine with 6). This is easily avoided - patch to make Java 6 compatible in there.
