### PR TITLE
Redstone controlled factories

### DIFF
--- a/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
+++ b/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
@@ -52,6 +52,8 @@ public class FactoryModPlugin extends JavaPlugin
 	public static boolean DISABLE_EXPERIENCE;
 	public static long DISREPAIR_PERIOD;
 	public static long REPAIR_PERIOD;
+	public static boolean REDSTONE_START_ENABLED;
+	public static boolean LEVER_OUTPUT_ENABLED;
 	
 	public void onEnable()
 	{
@@ -115,6 +117,10 @@ public class FactoryModPlugin extends JavaPlugin
 		//The length of time it takes a factory to go to 0% health
 		REPAIR_PERIOD = config.getLong("production_general.repair_period",28)*24*60*60*1000;
 		//Disable recipes which result in the following items
+		//Do we output the running state with a lever?
+		LEVER_OUTPUT_ENABLED = config.getBoolean("general.lever_output_enabled",true);
+		//Do we allow factories to be started with redstone?
+		REDSTONE_START_ENABLED = config.getBoolean("general.redstone_start_enabled",true);
 		int g = 0;
 		Iterator<String> disabledRecipes=config.getStringList("crafting.disable").iterator();
 		while(disabledRecipes.hasNext())

--- a/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
+++ b/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
@@ -17,6 +17,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import com.github.igotyou.FactoryMod.FactoryObject.FactoryType;
 import com.github.igotyou.FactoryMod.interfaces.Properties;
 import com.github.igotyou.FactoryMod.listeners.FactoryModListener;
+import com.github.igotyou.FactoryMod.listeners.RedstoneListener;
 import com.github.igotyou.FactoryMod.managers.FactoryModManager;
 import com.github.igotyou.FactoryMod.properties.ProductionProperties;
 import com.github.igotyou.FactoryMod.recipes.ProductionRecipe;
@@ -73,6 +74,7 @@ public class FactoryModPlugin extends JavaPlugin
 		try
 		{
 			getServer().getPluginManager().registerEvents(new FactoryModListener(manager, manager.getProductionManager()), this);
+			getServer().getPluginManager().registerEvents(new RedstoneListener(manager, manager.getProductionManager()), this);
 		}
 		catch(Exception e)
 		{

--- a/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
+++ b/src/com/github/igotyou/FactoryMod/FactoryModPlugin.java
@@ -220,7 +220,7 @@ public class FactoryModPlugin extends JavaPlugin
 			ItemList<NamedItemStack> fuel=getItems(configSection.getConfigurationSection("fuel"));
 			if(fuel.isEmpty())
 			{
-				fuel=new ItemList<>();
+				fuel=new ItemList<NamedItemStack>();
 				fuel.add(new NamedItemStack(Material.getMaterial("COAL"),1,(short)1,"Charcoal"));
 			}
 			int fuelTime=configSection.getInt("fuel_time",2);
@@ -242,7 +242,7 @@ public class FactoryModPlugin extends JavaPlugin
 	}
 	private List<ProbabilisticEnchantment> getEnchantments(ConfigurationSection configEnchantments)
 	{
-		List<ProbabilisticEnchantment> enchantments=new ArrayList<>();
+		List<ProbabilisticEnchantment> enchantments=new ArrayList<ProbabilisticEnchantment>();
 		if(configEnchantments!=null)
 		{
 			Iterator<String> names=configEnchantments.getKeys(false).iterator();
@@ -264,7 +264,7 @@ public class FactoryModPlugin extends JavaPlugin
 	}
 	private ItemList<NamedItemStack> getItems(ConfigurationSection configItems)
 	{
-		ItemList<NamedItemStack> items=new ItemList<>();
+		ItemList<NamedItemStack> items=new ItemList<NamedItemStack>();
 		if(configItems!=null)
 		{
 			for(String commonName:configItems.getKeys(false))

--- a/src/com/github/igotyou/FactoryMod/Factorys/ProductionFactory.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/ProductionFactory.java
@@ -44,7 +44,7 @@ public class ProductionFactory extends FactoryObject implements Factory
 	{
 		super(factoryLocation, factoryInventoryLocation, factoryPowerSource, ProductionFactory.FACTORY_TYPE, subFactoryType);
 		this.productionFactoryProperties = (ProductionProperties) factoryProperties;
-		this.recipes=new ArrayList<> (productionFactoryProperties.getRecipes());
+		this.recipes=new ArrayList<ProductionRecipe> (productionFactoryProperties.getRecipes());
 		this.setRecipeToNumber(0);
 		this.currentRepair=0.0;
 		this.timeDisrepair=3155692597470L;//Year 2070, default starting value
@@ -203,7 +203,7 @@ public class ProductionFactory extends FactoryObject implements Factory
 	 */
 	public List<InteractionResponse> togglePower() 
 	{
-		List<InteractionResponse> response=new ArrayList<>();
+		List<InteractionResponse> response=new ArrayList<InteractionResponse>();
 		//if the factory is turned off
 		if (!active)
 		{
@@ -228,7 +228,7 @@ public class ProductionFactory extends FactoryObject implements Factory
 						//return a failure message, containing which materials are needed for the recipe
 						//[Requires the following: Amount Name, Amount Name.]
 						//[Requires one of the following: Amount Name, Amount Name.]
-						ItemList<NamedItemStack> needAll=new ItemList<>();
+						ItemList<NamedItemStack> needAll=new ItemList<NamedItemStack>();
 						needAll.addAll(currentRecipe.getInputs().getDifference(getInventory()));
 						needAll.addAll(currentRecipe.getRepairs().getDifference(getInventory()));
 						if(!needAll.isEmpty())
@@ -276,7 +276,7 @@ public class ProductionFactory extends FactoryObject implements Factory
 	 */
 	public List<InteractionResponse> toggleRecipes()
 	{
-		List<InteractionResponse> responses=new ArrayList<>();
+		List<InteractionResponse> responses=new ArrayList<InteractionResponse>();
 		//Is the factory off
 		if (!active)
 		{
@@ -497,7 +497,7 @@ public class ProductionFactory extends FactoryObject implements Factory
 	
 	public List<InteractionResponse> getChestResponse()
 	{
-		List<InteractionResponse> responses=new ArrayList<>();
+		List<InteractionResponse> responses=new ArrayList<InteractionResponse>();
 		String status=active ? "On" : "Off";
 		String percentDone=status.equals("On") ? " - "+Math.round(currentProductionTimer*100/currentRecipe.getProductionTime())+"% done." : "";
 		//Name: Status with XX% health.

--- a/src/com/github/igotyou/FactoryMod/Factorys/ProductionFactory.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/ProductionFactory.java
@@ -159,7 +159,9 @@ public class ProductionFactory extends FactoryObject implements Factory
 		active = true;
 		
 		// Set attached lever
-		setActivationLever(true);
+		if (FactoryModPlugin.LEVER_OUTPUT_ENABLED) {
+			setActivationLever(true);
+		}
 		
 		//lots of code to make the furnace light up, without loosing contents.
 		Furnace furnace = (Furnace) factoryPowerSourceLocation.getBlock().getState();
@@ -190,7 +192,9 @@ public class ProductionFactory extends FactoryObject implements Factory
 	{
 		if(active)
 		{
-			setActivationLever(false);
+			if (FactoryModPlugin.LEVER_OUTPUT_ENABLED) {
+				setActivationLever(false);
+			}
 			
 			//lots of code to make the furnace turn off, without loosing contents.
 			Furnace furnace = (Furnace) factoryPowerSourceLocation.getBlock().getState();

--- a/src/com/github/igotyou/FactoryMod/Factorys/ProductionFactory.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/ProductionFactory.java
@@ -172,9 +172,14 @@ public class ProductionFactory extends FactoryObject implements Factory
 		currentProductionTimer = 0;
 		
 		// Set attached lever
+		setActivationLever(true);
+	}
+
+	private void setActivationLever(boolean state) {
 		Block lever = findActivationLever();
 		if (lever != null) {
-			setLever(lever, true);
+			setLever(lever, state);
+			shotGunUpdate(factoryPowerSourceLocation.getBlock());
 		}
 	}
 
@@ -201,10 +206,7 @@ public class ProductionFactory extends FactoryObject implements Factory
 			//reset the production timer
 			currentProductionTimer = 0;
 			
-			Block lever = findActivationLever();
-			if (lever != null) {
-				setLever(lever, false);
-			}
+			setActivationLever(false);
 		}
 	}
 
@@ -597,6 +599,14 @@ public class ProductionFactory extends FactoryObject implements Factory
     		return null;
     	}
     }
+    
+    private void shotGunUpdate(Block block) {
+    	for (BlockFace direction : REDSTONE_FACES) {
+    		block.getRelative(direction).getState().update();
+    	}
+    }
+    
+    
 	/**
 	* Sets the toggled state of a single lever<br>
 	* <b>No Lever type check is performed</b>

--- a/src/com/github/igotyou/FactoryMod/Factorys/ProductionFactory.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/ProductionFactory.java
@@ -2,13 +2,17 @@ package com.github.igotyou.FactoryMod.Factorys;
 
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.block.Furnace;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.material.Lever;
+import org.bukkit.material.MaterialData;
 
 import com.github.igotyou.FactoryMod.FactoryModPlugin;
 import com.github.igotyou.FactoryMod.FactoryObject;
 import com.github.igotyou.FactoryMod.interfaces.Factory;
 import com.github.igotyou.FactoryMod.interfaces.Recipe;
+import com.github.igotyou.FactoryMod.listeners.RedstoneListener;
 import com.github.igotyou.FactoryMod.properties.ProductionProperties;
 import com.github.igotyou.FactoryMod.recipes.ProductionRecipe;
 import com.github.igotyou.FactoryMod.utility.InteractionResponse;
@@ -178,6 +182,14 @@ public class ProductionFactory extends FactoryObject implements Factory
 			furnace.setRawData(data);
 			furnace.update();
 			furnace.getInventory().setContents(oldContents);
+			Block controlLever = RedstoneListener.findAttachedLever(factoryPowerSourceLocation.getBlock());
+			if (controlLever != null) {
+				MaterialData md = controlLever.getState().getData();
+				if (md instanceof Lever) {
+					((Lever) md).setPowered(false);
+					controlLever.getState().update();
+				}
+			}
 			//put active to false
 			active = false;
 			//reset the production timer

--- a/src/com/github/igotyou/FactoryMod/Factorys/ProductionFactory.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/ProductionFactory.java
@@ -155,6 +155,12 @@ public class ProductionFactory extends FactoryObject implements Factory
 	 */
 	public void powerOn() 
 	{
+		//put active to true
+		active = true;
+		
+		// Set attached lever
+		setActivationLever(true);
+		
 		//lots of code to make the furnace light up, without loosing contents.
 		Furnace furnace = (Furnace) factoryPowerSourceLocation.getBlock().getState();
 		byte data = furnace.getData().getData();
@@ -165,14 +171,8 @@ public class ProductionFactory extends FactoryObject implements Factory
 		furnace.setRawData(data);
 		furnace.update();
 		furnace.getInventory().setContents(oldContents);
-		
-		//put active to true
-		active = true;
 		//reset the production timer
 		currentProductionTimer = 0;
-		
-		// Set attached lever
-		setActivationLever(true);
 	}
 
 	private void setActivationLever(boolean state) {
@@ -190,6 +190,8 @@ public class ProductionFactory extends FactoryObject implements Factory
 	{
 		if(active)
 		{
+			setActivationLever(false);
+			
 			//lots of code to make the furnace turn off, without loosing contents.
 			Furnace furnace = (Furnace) factoryPowerSourceLocation.getBlock().getState();
 			byte data = furnace.getData().getData();
@@ -205,8 +207,6 @@ public class ProductionFactory extends FactoryObject implements Factory
 			active = false;
 			//reset the production timer
 			currentProductionTimer = 0;
-			
-			setActivationLever(false);
 		}
 	}
 
@@ -602,7 +602,8 @@ public class ProductionFactory extends FactoryObject implements Factory
     
     private void shotGunUpdate(Block block) {
     	for (BlockFace direction : REDSTONE_FACES) {
-    		block.getRelative(direction).getState().update();
+    		Block neighbour = block.getRelative(direction);
+    		
     	}
     }
     
@@ -638,6 +639,7 @@ public class ProductionFactory extends FactoryObject implements Factory
 			// CraftBukkit end
 			lever.setData((byte) newData, true);
 			lever.getState().update();
+			Block attached = lever.getRelative(((Attachable) lever.getState().getData()).getAttachedFace());
 		}
 	}
 }

--- a/src/com/github/igotyou/FactoryMod/listeners/RedstoneListener.java
+++ b/src/com/github/igotyou/FactoryMod/listeners/RedstoneListener.java
@@ -78,6 +78,11 @@ public class RedstoneListener implements Listener {
 			return;
 		}
 		
+		// Allow this to be disabled with config
+		if (!FactoryModPlugin.REDSTONE_START_ENABLED) {
+			return;
+		}
+		
 		Block rsBlock = e.getBlock();
 		BlockFace[] directions = null;
 		if (rsBlock.getType() == Material.REDSTONE_WIRE) {

--- a/src/com/github/igotyou/FactoryMod/listeners/RedstoneListener.java
+++ b/src/com/github/igotyou/FactoryMod/listeners/RedstoneListener.java
@@ -50,8 +50,21 @@ public class RedstoneListener implements Listener {
 		}
 		
 		Block rsBlock = e.getBlock();
+		BlockFace[] directions = null;
+		if (rsBlock.getType() == Material.REDSTONE_WIRE) {
+			directions = ProductionFactory.REDSTONE_FACES;
+		} else if (rsBlock.getType() == Material.WOOD_BUTTON) {
+			directions = new BlockFace[] {((Attachable) rsBlock.getState().getData()).getAttachedFace()};
+		} else if (rsBlock.getType() == Material.STONE_BUTTON) {
+			directions = new BlockFace[] {((Attachable) rsBlock.getState().getData()).getAttachedFace()};
+		} else if (rsBlock.getType() == Material.LEVER) {
+			directions = new BlockFace[] {((Attachable) rsBlock.getState().getData()).getAttachedFace()};
+		} else {
+			return; // Don't care
+		}
 		
-		for (BlockFace direction : ProductionFactory.REDSTONE_FACES) {
+		
+		for (BlockFace direction : directions) {
 			Block block = rsBlock.getRelative(direction);
 			
 			//Is the block part of a factory?

--- a/src/com/github/igotyou/FactoryMod/listeners/RedstoneListener.java
+++ b/src/com/github/igotyou/FactoryMod/listeners/RedstoneListener.java
@@ -1,0 +1,115 @@
+package com.github.igotyou.FactoryMod.listeners;
+
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockRedstoneEvent;
+import org.bukkit.material.Attachable;
+import org.bukkit.material.Lever;
+import org.bukkit.material.MaterialData;
+
+import com.github.igotyou.FactoryMod.FactoryModPlugin;
+import com.github.igotyou.FactoryMod.Factorys.ProductionFactory;
+import com.github.igotyou.FactoryMod.managers.FactoryModManager;
+import com.github.igotyou.FactoryMod.managers.ProductionManager;
+import com.github.igotyou.FactoryMod.utility.InteractionResponse;
+import com.github.igotyou.FactoryMod.utility.InteractionResponse.InteractionResult;
+
+public class RedstoneListener implements Listener {
+	private static final BlockFace[] LEVER_FACES = {BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST, BlockFace.UP};
+	private FactoryModManager factoryMan;
+	//this is a lazy fix...
+	private ProductionManager productionMan;
+	
+	/**
+	 * Constructor
+	 */
+	public RedstoneListener(FactoryModManager factoryManager, ProductionManager productionManager)
+	{
+		this.factoryMan = factoryManager;
+		this.productionMan = productionManager;
+	}
+	
+
+	/**
+	 * Called when a block is charged.
+	 * When the furnace block is powered, starts the factory and toggles on any attached levers.
+	 * On completion, toggles off any attached levers.
+	 */
+    @EventHandler(ignoreCancelled = true)
+	public void redstoneChange(BlockRedstoneEvent e)
+	{
+		// Only trigger on transition from 0 to positive
+		if (e.getOldCurrent() > 0 || e.getNewCurrent() == 0) {
+			return;
+		}
+		
+		Block block = e.getBlock();
+		//Is the block part of a factory?
+		if(block.getType() == Material.FURNACE || block.getType() == Material.BURNING_FURNACE)
+		{
+			if (factoryMan.factoryExistsAt(block.getLocation()))
+			{
+				Block lever = findAttachedLever(block);
+				if (lever == null) {
+					// Not supposed to automate
+					return;
+				}
+				
+				//Is the factory a production factory?
+				if (productionMan.factoryExistsAt(block.getLocation()))
+				{
+					ProductionFactory factory = (ProductionFactory) productionMan.getFactory(block.getLocation());
+					
+					if (!factory.getActive()) {
+						// Try to start the factory
+						List<InteractionResponse> result = factory.togglePower();
+						if (result.size() == 1 && result.get(0).getInteractionResult() == InteractionResult.SUCCESS) {
+							// Succeeded at turning factory on
+							// Set attached lever
+							MaterialData leverData = lever.getState().getData();
+							if (leverData instanceof Lever) {
+								((Lever) leverData).setPowered(true);
+								lever.getState().update();
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+    
+    public static Block findAttachedLever(Block block) {
+		// Check sides for attached lever - required for automation
+		Block lever = null;
+		for (BlockFace face : LEVER_FACES) {
+			lever = block.getRelative(face);
+			if (lever.getType() == Material.LEVER) {
+			    Block attached = getAttachedBlock(lever);
+			    if (attached != null && attached.getLocation().equals(block.getLocation())) {
+					return lever;
+			    }
+			}
+		}
+		
+		return null;
+    }
+    
+    private static Block getAttachedBlock(Block lever) {
+    	BlockState state = lever.getState();
+    	MaterialData md = state.getData();
+    	if (md instanceof Attachable) {
+    		BlockFace face = ((Attachable) md).getAttachedFace();
+    		BlockFace direction = face.getOppositeFace();
+    		return lever.getRelative(direction);
+    	} else {
+    		return null;
+    	}
+    }
+}

--- a/src/com/github/igotyou/FactoryMod/listeners/RedstoneListener.java
+++ b/src/com/github/igotyou/FactoryMod/listeners/RedstoneListener.java
@@ -1,5 +1,8 @@
 package com.github.igotyou.FactoryMod.listeners;
 
+import static com.untamedears.citadel.Utility.getReinforcement;
+import static com.untamedears.citadel.Utility.isReinforced;
+
 import java.util.List;
 
 import org.bukkit.Bukkit;
@@ -9,6 +12,7 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.block.BlockRedstoneEvent;
 import org.bukkit.material.Attachable;
 import org.bukkit.material.Lever;
@@ -20,6 +24,7 @@ import com.github.igotyou.FactoryMod.managers.FactoryModManager;
 import com.github.igotyou.FactoryMod.managers.ProductionManager;
 import com.github.igotyou.FactoryMod.utility.InteractionResponse;
 import com.github.igotyou.FactoryMod.utility.InteractionResponse.InteractionResult;
+import com.untamedears.citadel.entity.PlayerReinforcement;
 
 public class RedstoneListener implements Listener {
 	private FactoryModManager factoryMan;
@@ -33,6 +38,30 @@ public class RedstoneListener implements Listener {
 	{
 		this.factoryMan = factoryManager;
 		this.productionMan = productionManager;
+	}
+	
+	@EventHandler(ignoreCancelled = true)
+	public void leverPlaced(BlockPlaceEvent e) {
+		if (e.getBlock().getType() != Material.LEVER) {
+			return;
+		}
+		
+		Block clicked = e.getBlockAgainst();
+		//is there a factory there? and if it has all its blocks
+		if (factoryMan.factoryExistsAt(clicked.getLocation())&&factoryMan.factoryWholeAt(clicked.getLocation()))
+		{
+			//if the player is allowed to interact with that block?
+			if ((!FactoryModPlugin.CITADEL_ENABLED || FactoryModPlugin.CITADEL_ENABLED && !isReinforced(clicked)) || 
+					(((PlayerReinforcement) getReinforcement(clicked)).isAccessible(e.getPlayer())))
+			{
+				// Allowed
+			}
+			//if the player is NOT allowed to interact with the clicked block
+			else
+			{
+				e.setCancelled(true);
+			}
+		}
 	}
 	
 

--- a/src/com/github/igotyou/FactoryMod/recipes/ProductionRecipe.java
+++ b/src/com/github/igotyou/FactoryMod/recipes/ProductionRecipe.java
@@ -42,7 +42,7 @@ public class ProductionRecipe implements Recipe
 	
 	public ProductionRecipe(String title,String recipeName,int productionTime,ItemList<NamedItemStack> repairs)
 	{
-		this(title,recipeName,productionTime,new ItemList<>(),new ItemList<>(),new ItemList<>(),new ArrayList<ProbabilisticEnchantment>(),false,repairs);
+		this(title,recipeName,productionTime,new ItemList<NamedItemStack>(),new ItemList<NamedItemStack>(),new ItemList<NamedItemStack>(),new ArrayList<ProbabilisticEnchantment>(),false,repairs);
 	}
 	
 	public boolean hasMaterials(Inventory inventory)

--- a/src/com/github/igotyou/FactoryMod/utility/ItemList.java
+++ b/src/com/github/igotyou/FactoryMod/utility/ItemList.java
@@ -109,7 +109,7 @@ public class ItemList<E extends NamedItemStack> extends ArrayList<E> {
 	}
 	public ItemList<NamedItemStack> removeOneFrom(Inventory inventory)
 	{
-		ItemList<NamedItemStack> itemList=new ItemList<>();
+		ItemList<NamedItemStack> itemList=new ItemList<NamedItemStack>();
 		for(NamedItemStack itemStack:this)
 		{
 			if(removeItemStack(inventory,itemStack))
@@ -122,7 +122,7 @@ public class ItemList<E extends NamedItemStack> extends ArrayList<E> {
 	}
 	public ItemList<NamedItemStack> getDifference(Inventory inventory)
 	{
-		ItemList<NamedItemStack> missingItems=new ItemList<>();
+		ItemList<NamedItemStack> missingItems=new ItemList<NamedItemStack>();
 		for(NamedItemStack itemStack:this)
 		{
 			int difference=itemStack.getAmount()-amountAvailable(inventory, itemStack);
@@ -272,7 +272,7 @@ public class ItemList<E extends NamedItemStack> extends ArrayList<E> {
 	}
 	public ItemList<NamedItemStack> getMultiple(int multiplier)
 	{
-		ItemList<NamedItemStack> multipliedItemList=new ItemList<>();
+		ItemList<NamedItemStack> multipliedItemList=new ItemList<NamedItemStack>();
 		for (NamedItemStack itemStack:this)
 		{
 			NamedItemStack itemStackClone=itemStack.clone();


### PR DESCRIPTION
This update provides redstone control for factories by connecting the redstone to the furnace block.

To make a factory redstone-sensitive it _must_ have a lever attached to the furnace. Without this, it will not be controlled by the redstone. A redstone pulse to redstone wire next to the furnace (any side) will turn the factory on if it's ready. Likewise, flipping the lever or pressing an additional button attached to the furnace block will count as a redstone pulse. _At the moment it will not respond to a repeater unless you also stick redstone on it_.

When the factory starts for any reason, the lever is switched to the on position. This sends out a redstone signal which can identify that the factory is running. When turned off for any reason, the factory is turned off. At the moment, turning the lever off by hand does nothing (hope to make this cancel the job in another update).

This can be combined with hoppers, etc, to build sophisticated factory control systems.
