### PR TITLE
Factory inputs not being checked for printing press.

### DIFF
--- a/src/com/github/igotyou/FactoryMod/Factorys/BaseFactory.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/BaseFactory.java
@@ -113,7 +113,7 @@ public abstract class BaseFactory extends FactoryObject implements Factory {
 	}
 	
 	public boolean checkHasMaterials() {
-		return true;
+		return getAllInputs().allIn(getInventory());
 	}
 
 	/**


### PR DESCRIPTION
Stubbed routine in separating out BaseFactory stopped the factory from checking for inputs. Please do not deploy a version with this split without this fix.

EDIT: This didn't affect production factories so isn't as critical as I thought. ProductionFactory overrides the affected method with a valid version. It was still allowing printing plates and printing press repairs to be done for free though.
