### PR TITLE
Printing Press Fixes

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -102,7 +102,8 @@ printing_presses:
      repair:
         "Iron block":
            material: 'IRON_BLOCK'
-           amount: 5
+           amount: 1
+     repair_multiple: 5
      binding: # Each
         Leather:
            material: 'LEATHER'

--- a/src/com/github/igotyou/FactoryMod/Factorys/BaseFactory.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/BaseFactory.java
@@ -113,7 +113,7 @@ public abstract class BaseFactory extends FactoryObject implements Factory {
 	}
 	
 	public boolean checkHasMaterials() {
-		return true;
+		return getAllInputs().allIn(getInventory());
 	}
 
 	/**

--- a/src/com/github/igotyou/FactoryMod/Factorys/BaseFactory.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/BaseFactory.java
@@ -175,7 +175,7 @@ public abstract class BaseFactory extends FactoryObject implements Factory {
 						//[Requires the following: Amount Name, Amount Name.]
 						//[Requires one of the following: Amount Name, Amount Name.]
 						
-						ItemList<NamedItemStack> needAll=getAllInputs();
+						ItemList<NamedItemStack> needAll=new ItemList<NamedItemStack>();
 						needAll.addAll(getAllInputs().getDifference(getInventory()));
 						if(!needAll.isEmpty())
 						{

--- a/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
@@ -233,7 +233,7 @@ public class PrintingPress extends BaseFactory {
 		boolean inputStall = false;
 		if (hasPages) {
 			// Check bindings
-			int expectedBindings = (int) Math.floor((double) containedPaper + printingPressProperties.getPagesPerLot() / (double) getPrintResult().pageCount());
+			int expectedBindings = (int) Math.floor((double) (containedPaper + printingPressProperties.getPagesPerLot()) / (double) getPrintResult().pageCount());
 			boolean hasBindings = true;
 			ItemList<NamedItemStack> allBindings = new ItemList<NamedItemStack>();
 			if (expectedBindings > containedBindings) {

--- a/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
@@ -573,7 +573,7 @@ public class PrintingPress extends BaseFactory {
 			meta.setDisplayName(title);
 			List<String> lore = new ArrayList<String>();
 			if (pages.size() > 0) {
-				lore.add(filterPageLore(pages.get(0)));
+				lore.addAll(filterPageLore(pages.get(0)));
 			}
 			meta.setLore(lore);
 			book.setItemMeta(meta);
@@ -586,7 +586,7 @@ public class PrintingPress extends BaseFactory {
 			meta.setDisplayName(title);
 			List<String> lore = new ArrayList<String>();
 			if (pages.size() > 0) {
-				lore.add(filterPageLore(pages.get(0)));
+				lore.addAll(filterPageLore(pages.get(0)));
 			}
 			if (author.equals("")) {
 				lore.add(String.format("§2#%d", watermark));
@@ -598,21 +598,20 @@ public class PrintingPress extends BaseFactory {
 			return book;
 		}
 		
-		private String filterPageLore(String lore) {
+		private List<String> filterPageLore(String lore) {
 			// Remove green
 			lore = lore.replace("§2", "");
 			
 			// Remove line breaks
-			lore = lore.replace("\n", "").replace("\r", "");
+			lore = lore.replaceAll("[ \r\n]+", " ");
 			
 			// Limit length
 			lore = PrettyLore.limitLengthEllipsis(lore, PAGE_LORE_LENGTH_LIMIT);
 			
 			// Split in to lines based on length
 			List<String> lines = PrettyLore.splitLines(lore, PAGE_LORE_LINE_LIMIT);
-			lore = PrettyLore.combineLines(lines);
 			
-			return lore;
+			return lines;
 		}
 		
 		public int hashCode() {

--- a/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
@@ -338,7 +338,7 @@ public class PrintingPress extends BaseFactory {
 		boolean inputStall = false;
 		if (hasPages) {
 			// Check security materials
-			int expectedExtras = (int) Math.ceil((double) containedPaper + printingPressProperties.getPamphletsPerLot() / (double) getPrintResult().pageCount());
+			int expectedExtras = (int) Math.ceil((double) containedPaper + printingPressProperties.getPamphletsPerLot());
 			boolean hasExtras = true;
 			ItemList<NamedItemStack> allSecurityMaterials = new ItemList<NamedItemStack>();
 			if (expectedExtras > containedSecurityMaterials) {

--- a/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
@@ -233,7 +233,7 @@ public class PrintingPress extends BaseFactory {
 		boolean inputStall = false;
 		if (hasPages) {
 			// Check bindings
-			int expectedBindings = (int) Math.ceil((double) containedPaper + printingPressProperties.getPagesPerLot() / (double) getPrintResult().pageCount());
+			int expectedBindings = (int) Math.floor((double) containedPaper + printingPressProperties.getPagesPerLot() / (double) getPrintResult().pageCount());
 			boolean hasBindings = true;
 			ItemList<NamedItemStack> allBindings = new ItemList<NamedItemStack>();
 			if (expectedBindings > containedBindings) {

--- a/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
@@ -559,7 +559,6 @@ public class PrintingPress extends BaseFactory {
 		public NamedItemStack toBook() {
 			NamedItemStack book = new NamedItemStack(Material.WRITTEN_BOOK, 1, (short) 0, "book");
 			BookMeta meta = (BookMeta) book.getItemMeta();
-			meta.setDisplayName(title);
 			meta.setTitle(title);
 			meta.setAuthor(author);
 			meta.setPages(pages);

--- a/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
@@ -231,19 +231,28 @@ public class PrintingPress extends BaseFactory {
 		boolean hasPages = pages.allIn(getInventory());
 		boolean inputStall = false;
 		if (hasPages) {
-			pages.removeFrom(getInventory());
-			containedPaper += printingPressProperties.getPagesPerLot();
+			// Check bindings
+			int expectedBindings = (int) Math.ceil((double) containedPaper + printingPressProperties.getPagesPerLot() / (double) getPrintResult().pageCount());
+			boolean hasBindings = true;
+			ItemList<NamedItemStack> allBindings = new ItemList<NamedItemStack>();
+			if (expectedBindings > containedBindings) {
+				int neededBindings = expectedBindings - containedBindings;
+				allBindings = printingPressProperties.getBindingMaterials().getMultiple(neededBindings);
+				hasBindings = allBindings.allIn(getInventory());
+			}
 			
-			// Load bindings
-			int expectedBindings = (int) Math.ceil((double) containedPaper / (double) getPrintResult().pageCount());
-			while (containedBindings < expectedBindings) {
-				if (printingPressProperties.getBindingMaterials().allIn(getInventory())) {
-					printingPressProperties.getBindingMaterials().removeFrom(getInventory());
-					containedBindings += 1;
-				} else {
-					inputStall = true;
-					break;
+			if (hasBindings) {
+				pages.removeFrom(getInventory());
+				containedPaper += printingPressProperties.getPagesPerLot();
+				
+				while (containedBindings < expectedBindings) {
+					if (printingPressProperties.getBindingMaterials().allIn(getInventory())) {
+						printingPressProperties.getBindingMaterials().removeFrom(getInventory());
+						containedBindings += 1;
+					}
 				}
+			} else {
+				inputStall = true;
 			}
 		} else {
 			inputStall = true;
@@ -327,18 +336,29 @@ public class PrintingPress extends BaseFactory {
 		boolean hasPages = pages.allIn(getInventory());
 		boolean inputStall = false;
 		if (hasPages) {
-			pages.removeFrom(getInventory());
-			containedPaper += printingPressProperties.getPamphletsPerLot();
+			// Check security materials
+			int expectedExtras = (int) Math.ceil((double) containedPaper + printingPressProperties.getPamphletsPerLot() / (double) getPrintResult().pageCount());
+			boolean hasExtras = true;
+			ItemList<NamedItemStack> allSecurityMaterials = new ItemList<NamedItemStack>();
+			if (expectedExtras > containedSecurityMaterials) {
+				int neededBindings = expectedExtras - containedSecurityMaterials;
+				allSecurityMaterials = printingPressProperties.getSecurityMaterials().getMultiple(neededBindings);
+				hasExtras = allSecurityMaterials.allIn(getInventory());
+			}
 			
-			// Load security materials if security notes
-			while (containedSecurityMaterials < containedPaper) {
-				if (printingPressProperties.getSecurityMaterials().allIn(getInventory())) {
-					printingPressProperties.getSecurityMaterials().removeFrom(getInventory());
-					containedSecurityMaterials += printingPressProperties.getSecurityNotesPerLot();
-				} else {
-					inputStall = true;
-					break;
+			if (hasExtras) {
+				pages.removeFrom(getInventory());
+				containedPaper += printingPressProperties.getPamphletsPerLot();
+				
+				// Load security materials if security notes
+				while (containedSecurityMaterials < containedPaper) {
+					if (printingPressProperties.getSecurityMaterials().allIn(getInventory())) {
+						printingPressProperties.getSecurityMaterials().removeFrom(getInventory());
+						containedSecurityMaterials += printingPressProperties.getSecurityNotesPerLot();
+					}
 				}
+			} else {
+				inputStall = true;
 			}
 		} else {
 			inputStall = true;

--- a/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
@@ -21,6 +21,7 @@ import com.github.igotyou.FactoryMod.utility.InteractionResponse;
 import com.github.igotyou.FactoryMod.utility.ItemList;
 import com.github.igotyou.FactoryMod.utility.NamedItemStack;
 import com.github.igotyou.FactoryMod.utility.InteractionResponse.InteractionResult;
+import com.github.igotyou.FactoryMod.utility.PrettyLore;
 
 public class PrintingPress extends BaseFactory {
 	
@@ -498,6 +499,7 @@ public class PrintingPress extends BaseFactory {
 	
 	private class PrintResult {
 		private static final int PAGE_LORE_LENGTH_LIMIT = 140;
+		private static final int PAGE_LORE_LINE_LIMIT = 35;
 		private List<String> pages;
 		private String title;
 		private String author;
@@ -570,7 +572,7 @@ public class PrintingPress extends BaseFactory {
 			meta.setDisplayName(title);
 			List<String> lore = new ArrayList<String>();
 			if (pages.size() > 0) {
-				lore.add(limitPageLore(pages.get(0)));
+				lore.add(filterPageLore(pages.get(0)));
 			}
 			meta.setLore(lore);
 			book.setItemMeta(meta);
@@ -583,7 +585,7 @@ public class PrintingPress extends BaseFactory {
 			meta.setDisplayName(title);
 			List<String> lore = new ArrayList<String>();
 			if (pages.size() > 0) {
-				lore.add(limitPageLore(pages.get(0)));
+				lore.add(filterPageLore(pages.get(0)));
 			}
 			if (author.equals("")) {
 				lore.add(String.format("§2#%d", watermark));
@@ -595,13 +597,21 @@ public class PrintingPress extends BaseFactory {
 			return book;
 		}
 		
-		private String limitPageLore(String in) {
-			in = in.replace("§2", "");
-			if (in.length() > PAGE_LORE_LENGTH_LIMIT) {
-				return in.substring(0, PAGE_LORE_LENGTH_LIMIT - 3) + "...";
-			} else {
-				return in;
-			}
+		private String filterPageLore(String lore) {
+			// Remove green
+			lore = lore.replace("§2", "");
+			
+			// Remove line breaks
+			lore = lore.replace("\n", "").replace("\r", "");
+			
+			// Limit length
+			lore = PrettyLore.limitLengthEllipsis(lore, PAGE_LORE_LENGTH_LIMIT);
+			
+			// Split in to lines based on length
+			List<String> lines = PrettyLore.splitLines(lore, PAGE_LORE_LINE_LIMIT);
+			lore = PrettyLore.combineLines(lines);
+			
+			return lore;
 		}
 		
 		public int hashCode() {

--- a/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
@@ -371,6 +371,10 @@ public class PrintingPress extends BaseFactory {
 		}
 		return newQ;
 	}
+
+	public boolean isRepairing() {
+		return mode == OperationMode.REPAIR;
+	}
 	
 	/**
 	 * Returns either a success or error message.
@@ -425,7 +429,7 @@ public class PrintingPress extends BaseFactory {
 		//[Will repair XX% of the factory]
 		if(!getRepairs().isEmpty()&&maintenanceActive)
 		{
-			int amountAvailable=getRepairs().amountAvailable(getPowerSourceInventory());
+			int amountAvailable=getRepairs().amountAvailable(getInventory());
 			int amountRepaired=amountAvailable>currentRepair ? (int) Math.ceil(currentRepair) : amountAvailable;
 			int percentRepaired=(int) (( (double) amountRepaired)/printingPressProperties.getMaxRepair()*100);
 			responses.add(new InteractionResponse(InteractionResult.SUCCESS,"Will repair "+String.valueOf(percentRepaired)+"% of the factory with "+getRepairs().getMultiple(amountRepaired).toString()+"."));

--- a/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
+++ b/src/com/github/igotyou/FactoryMod/Factorys/PrintingPress.java
@@ -342,8 +342,9 @@ public class PrintingPress extends BaseFactory {
 			boolean hasExtras = true;
 			ItemList<NamedItemStack> allSecurityMaterials = new ItemList<NamedItemStack>();
 			if (expectedExtras > containedSecurityMaterials) {
-				int neededBindings = expectedExtras - containedSecurityMaterials;
-				allSecurityMaterials = printingPressProperties.getSecurityMaterials().getMultiple(neededBindings);
+				int neededExtras = expectedExtras - containedSecurityMaterials;
+				int neededExtraLots = (int) Math.ceil((double) neededExtras / (double) printingPressProperties.getSecurityNotesPerLot());
+				allSecurityMaterials = printingPressProperties.getSecurityMaterials().getMultiple(neededExtraLots);
 				hasExtras = allSecurityMaterials.allIn(getInventory());
 			}
 			

--- a/src/com/github/igotyou/FactoryMod/properties/PrintingPressProperties.java
+++ b/src/com/github/igotyou/FactoryMod/properties/PrintingPressProperties.java
@@ -123,7 +123,7 @@ public class PrintingPressProperties {
 		ItemList<NamedItemStack> ppSecurityCost=plugin.getItems(costs.getConfigurationSection("security_lot"));
 		int securityNotesPerLot = costs.getInt("security_notes_per_lot",24);
 		int ppEnergyTime = configPrintingPresses.getInt("fuel_time", 10);
-		int ppRepair = configPrintingPresses.getInt("max_repair",100);
+		int ppRepair = costs.getInt("repair_multiple",1);
 		String ppName = configPrintingPresses.getString("name", "Printing Press");
 		int paperRate = configPrintingPresses.getInt("paper_rate",3);
 		int pageLead = configPrintingPresses.getInt("page_lead",12);

--- a/src/com/github/igotyou/FactoryMod/utility/PrettyLore.java
+++ b/src/com/github/igotyou/FactoryMod/utility/PrettyLore.java
@@ -1,0 +1,57 @@
+package com.github.igotyou.FactoryMod.utility;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PrettyLore {
+	public static List<String> splitLines(String paragraph, int lineLength) {
+		List<String> lines = new ArrayList<String>();
+		int lineStart = 0;
+		int lastSpace = -1;
+		while (true) {
+			int nextSpace = paragraph.indexOf(' ', lastSpace + 1);
+			if (nextSpace == -1) {
+				// End of paragraph
+				lines.add(paragraph.substring(lineStart, paragraph.length()));
+				break;
+			} else if (nextSpace - lineStart > lineLength) {
+				if (lastSpace + 1 == lineStart) {
+					// Block of more than lineLength without a space in it - has to be one line
+					lastSpace = nextSpace;
+				}
+
+				// End of line at last space
+				lines.add(paragraph.substring(lineStart, lastSpace));
+				lineStart = lastSpace + 1;
+			} else {
+				lastSpace = nextSpace;
+			}
+		}
+		return lines;
+	}
+
+	public static String limitLengthEllipsis(String in, int lengthLimit) {
+		return limitLengthEllipsis(in, lengthLimit, "...");
+	}
+	
+	public static String limitLengthEllipsis(String in, int lengthLimit, String ellipsisText) {
+		if (in.length() > lengthLimit) {
+			return in.substring(0, lengthLimit - ellipsisText.length()) + ellipsisText;
+		} else {
+			return in;
+		}
+	}
+	
+	public static String combineLines(List<String> lines) {
+		StringBuilder sb = new StringBuilder();
+		boolean firstLine = true;
+		for (String line : lines) {
+			if (firstLine) {
+				sb.append("\n");
+				firstLine = false;
+			}
+			sb.append(line);
+		}
+		return sb.toString();
+	}
+}


### PR DESCRIPTION
A series of fixes and tweaks for the printing press following a thorough test.
- Fix checking inputs for repair and plates
- Don't set display name on books - not required.
- Change to repairs to correct misunderstood multiplier. Now repair cost is 1/10 of construction rather than 10 times construction!
- When starting a run without required materials, was reporting the needed materials twice.
- Made feed of materials clearer - takes materials only if all page, binding and security materials needed are present. Previously gobbled paper and ink even if missing bindings or security materials.
- Better formatting to create pamphlet and security note lore. Adds line breaks between words to limit line length to 35 characters. Total limit is still 140 characters, so will be maximum of 5 lines (breaks early for word boundaries). Stops lore from overflowing off end of screen.

Affected issues:
- Closes #32
- Closes #34
- Closes #35
