### PR TITLE
Update Config.yml to fix Advanced Redstone Factory

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1674,7 +1674,7 @@ production_factories:
         amount: 9
       Glowstone:
         material: GLOWSTONE
-        amount: 25
+        amount: 2
       Iron_Ingot:
         material: IRON_INGOT
         amount: 6


### PR DESCRIPTION
Glowstone cost was wrong in the repair of Advance Redstone Factory
